### PR TITLE
Fixed bug where the remove offset table was not updated

### DIFF
--- a/lib/arrayChanges.js
+++ b/lib/arrayChanges.js
@@ -42,16 +42,22 @@ module.exports = function arrayChanges(actual, expected, equal, similar, include
         });
     }, function (itemsDiff) {
 
-        var removeTable = [];
         function offsetIndex(index) {
-            return index + (removeTable[index - 1] || 0);
+            var offsetIndex = 0;
+            var i;
+            for (i = 0; i < mutatedArray.length && offsetIndex < index; i += 1) {
+                if (mutatedArray[i].type !== 'remove') {
+                    offsetIndex++;
+                }
+            }
+
+            return i;
         }
 
         var removes = itemsDiff.filter(function (diffItem) {
             return diffItem.type === 'remove';
         });
 
-        var removesByIndex = {};
         var removedItems = 0;
         removes.forEach(function (diffItem) {
             var removeIndex = removedItems + diffItem.index;
@@ -59,26 +65,14 @@ module.exports = function arrayChanges(actual, expected, equal, similar, include
                 v.type = 'remove';
             });
             removedItems += diffItem.howMany;
-            removesByIndex[diffItem.index] = removedItems;
         });
-
-        function updateRemoveTable() {
-            removedItems = 0;
-            Array.prototype.forEach.call(actual, function (_, index) {
-                removedItems += removesByIndex[index] || 0;
-                removeTable[index] = removedItems;
-            });
-        }
-
-        updateRemoveTable();
 
         var moves = itemsDiff.filter(function (diffItem) {
             return diffItem.type === 'move';
         });
 
-        var movedItems = 0;
         moves.forEach(function (diffItem) {
-            var moveFromIndex = offsetIndex(diffItem.from);
+            var moveFromIndex = offsetIndex(diffItem.from + 1) - 1;
             var removed = mutatedArray.slice(moveFromIndex, diffItem.howMany + moveFromIndex);
             var added = removed.map(function (v) {
                 return extend({}, v, { last: false, type: 'insert' });
@@ -86,10 +80,8 @@ module.exports = function arrayChanges(actual, expected, equal, similar, include
             removed.forEach(function (v) {
                 v.type = 'remove';
             });
-            Array.prototype.splice.apply(mutatedArray, [offsetIndex(diffItem.to), 0].concat(added));
-            movedItems += diffItem.howMany;
-            removesByIndex[diffItem.from] = movedItems;
-            updateRemoveTable();
+            var insertIndex = offsetIndex(diffItem.to);
+            Array.prototype.splice.apply(mutatedArray, [insertIndex, 0].concat(added));
         });
 
         var inserts = itemsDiff.filter(function (diffItem) {

--- a/package.json
+++ b/package.json
@@ -29,10 +29,12 @@
   "devDependencies": {
     "browserify": "10.2.4",
     "bundle-collapser": "1.2.0",
+    "chance-generators": "1.18.0",
     "coveralls": "2.11.2",
     "istanbul": "0.3.17",
     "jshint": "2.7.0",
     "mocha": "2.2.5",
-    "unexpected": "10.1.0"
+    "unexpected": "10.1.0",
+    "unexpected-check": "1.11.0"
   }
 }


### PR DESCRIPTION
I was trying to optimise the remove offset calculation with a table, but it does not make sense as the table has to be recalculated for every mutation. There were some cases where I was not recalculating the table probably.

unexpected-check thinks it is working:

![screen shot 2016-09-14 at 13 05 53](https://cloud.githubusercontent.com/assets/90802/18510080/6b415b1e-7a7c-11e6-846e-fb7da90ef69f.png)
